### PR TITLE
Added an exception to JWTGuard->user()

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -76,6 +76,8 @@ class JWTGuard implements Guard
 
             return $this->user = $this->provider->retrieveById($id);
         }
+        
+        throw new JWTException();
     }
 
     /**


### PR DESCRIPTION
Made JWTGuard->user() throw an exception instead of simply returning nothing. If it returns null, it's too annoying to check everywhere. An exception thrown would avoid that.
